### PR TITLE
Fix typographical error in header

### DIFF
--- a/main.c
+++ b/main.c
@@ -4,7 +4,7 @@
  * main module for serproxy
  *
  * 1999 - Stefano Busti (original version)
- * 2021 - davidhayter (add chracter mode support)
+* 2021 - davidhayter (add character mode support)
  */
 
 


### PR DESCRIPTION
## Summary
- correct "chracter" to "character" in `main.c`

## Testing
- `make`

## Summary by Sourcery

Chores:
- Correct typo "chracter" to "character" in main.c header comment